### PR TITLE
Modernize JS: template literals and const declarations

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -55,9 +55,9 @@
   <!-- Default Statcounter code for Chuck Findlay's Homepage
   https://chuck.findlayis.me -->
   <script type="text/javascript">
-    var sc_project=13077914; 
-    var sc_invisible=1; 
-    var sc_security="b7bd04d1"; 
+    const sc_project=13077914;
+    const sc_invisible=1;
+    const sc_security="b7bd04d1";
     </script>
     <script type="text/javascript"
     src="https://www.statcounter.com/counter/counter.js"

--- a/html/js/main.js
+++ b/html/js/main.js
@@ -1,47 +1,51 @@
 function viewHome() {
     $('#content').fadeOut(function() {
-        $(this).html('\
-            <h3>Software Developer in Canada</h3>\
-            <p class="lead"><a target="_blank" href="https://chuck.findlayis.me/pubkey.asc">My public GPG key (click)</a></p>\
-            <p>I write code both professionally and as a hobby</p>\
-            <img src="img/vscode-sshot.png" class="img-fluid rounded mb-3" alt="Visual Studio Code Screenshot">\
-            <p>Site lovingly handcrafted (no WYSIWYG editor) by myself with a CI/CD pipeline. Bootstrap used to make it prettier.</p>\
-        ').fadeIn();
+        $(this).html(`
+            <h3>Software Developer in Canada</h3>
+            <p class="lead"><a target="_blank" href="https://chuck.findlayis.me/pubkey.asc">My public GPG key (click)</a></p>
+            <p>I write code both professionally and as a hobby</p>
+            <img src="img/vscode-sshot.png" class="img-fluid rounded mb-3" alt="Visual Studio Code Screenshot">
+            <p>Site lovingly handcrafted (no WYSIWYG editor) by myself with a CI/CD pipeline. Bootstrap used to make it prettier.</p>
+        `).fadeIn();
     });
 }
 
 function viewContact() {
     $('#content').fadeOut(function() {
-        $(this).html('<h3 class="lead">Contact</h3>\
-        <p>Email is the preferred way to contact me async, but Linkedin is good too. I don\'t do Twitter/X, Facebook, etc.</p>\
-        <p>PGP key is available <a href="https://chuck.findlayis.me/pubkey.asc" target="_blank" class="text-secondary">here</a> to use for emails if you\'re the type to do encrypted chats.</p>\
-        <ul class="list-group">\
-            <li class="list-group-item list-group-item-secondary"><a href="mailto:chuck@findlayis.me" class="text-secondary">chuck@findlayis.me</a></li>\
-            <li class="list-group-item list-group-item-secondary"><a href="https://www.linkedin.com/in/charlesrfindlay/" target="_blank" class="text-secondary">Linkedin</a></li>\
-        </ul>').fadeIn();
+        $(this).html(`
+            <h3 class="lead">Contact</h3>
+            <p>Email is the preferred way to contact me async, but Linkedin is good too. I don't do Twitter/X, Facebook, etc.</p>
+            <p>PGP key is available <a href="https://chuck.findlayis.me/pubkey.asc" target="_blank" class="text-secondary">here</a> to use for emails if you're the type to do encrypted chats.</p>
+            <ul class="list-group">
+                <li class="list-group-item list-group-item-secondary"><a href="mailto:chuck@findlayis.me" class="text-secondary">chuck@findlayis.me</a></li>
+                <li class="list-group-item list-group-item-secondary"><a href="https://www.linkedin.com/in/charlesrfindlay/" target="_blank" class="text-secondary">Linkedin</a></li>
+            </ul>
+        `).fadeIn();
     });
 }
 
 function viewCodingLanguages() {
     $('#content').fadeOut(function() {
-        $(this).html('<h3>Coding Portfolio</h3>\
-        <p>By no means an exhaustive list of languages/technologies I have experience in, but a few links to examples of projects I\'ve written in a list of languages. Not all projects are complete, but you can at least see my thought process in those. Almost all have fully functional automated builds, with some having full CI/CD for myself.</p>\
-        <ul class="list-group bg-dark">\
-            <li class="list-group-item list-group-item-dark">Go (Golang)<br>\
-            <a href="https://github.com/cfindlayisme/wmb" class="text-secondary" target="_blank">wmb (Webhook Message Bot, IRC)</a><br>\
-            <a href="https://github.com/cfindlayisme/rss-wmb" class="text-secondary" target="_blank">rss-wmb (rss feed -> wmb -> IRC message)</a><br>\
-            <a href="https://github.com/cfindlayisme/go-utils" class="text-secondary" target="_blank">go-utils library (Some utility functions for Go development)</a><br>\
-            <a href="https://github.com/cfindlayisme/go-types" class="text-secondary" target="_blank">go-types library (Extended types/structs for Go - ie, Temperature object)</a><br>\
-            <a href="https://github.com/cfindlayisme/ssh-bastion" class="text-secondary" target="_blank">ssh-bastion (SSH bastion host)</a>\
-            </li>\
-            <li class="list-group-item list-group-item-dark">JavaScript (Node, etc)<br>\
-            <a href="https://github.com/cfindlayisme/chuck.findlayis.me-docker" class="text-secondary" target="_blank">This site (link to repo)</a><br>\
-            <a href="https://gsmanager.serverfail.party" class="text-secondary" target="_blank">gsmanager (game server control panel - closed source)</a><br>\
-            <a href="https://darkfoe.ca" class="text-secondary" target="_blank">My blog (closed source - NodeJS)</a></li>\
-            <li class="list-group-item list-group-item-dark">Docker<br>\
-            <a href="https://github.com/cfindlayisme/factorio-docker" target="_blank" class="text-secondary">factorio-docker</a><br>\
-            <a href="https://github.com/cfindlayisme/terraria-docker" target="_blank" class="text-secondary">terraria-docker</a><br>\
-        ').fadeIn();
+        $(this).html(`
+            <h3>Coding Portfolio</h3>
+            <p>By no means an exhaustive list of languages/technologies I have experience in, but a few links to examples of projects I've written in a list of languages. Not all projects are complete, but you can at least see my thought process in those. Almost all have fully functional automated builds, with some having full CI/CD for myself.</p>
+            <ul class="list-group bg-dark">
+                <li class="list-group-item list-group-item-dark">Go (Golang)<br>
+                <a href="https://github.com/cfindlayisme/wmb" class="text-secondary" target="_blank">wmb (Webhook Message Bot, IRC)</a><br>
+                <a href="https://github.com/cfindlayisme/rss-wmb" class="text-secondary" target="_blank">rss-wmb (rss feed -> wmb -> IRC message)</a><br>
+                <a href="https://github.com/cfindlayisme/go-utils" class="text-secondary" target="_blank">go-utils library (Some utility functions for Go development)</a><br>
+                <a href="https://github.com/cfindlayisme/go-types" class="text-secondary" target="_blank">go-types library (Extended types/structs for Go - ie, Temperature object)</a><br>
+                <a href="https://github.com/cfindlayisme/ssh-bastion" class="text-secondary" target="_blank">ssh-bastion (SSH bastion host)</a>
+                </li>
+                <li class="list-group-item list-group-item-dark">JavaScript (Node, etc)<br>
+                <a href="https://github.com/cfindlayisme/chuck.findlayis.me-docker" class="text-secondary" target="_blank">This site (link to repo)</a><br>
+                <a href="https://gsmanager.serverfail.party" class="text-secondary" target="_blank">gsmanager (game server control panel - closed source)</a><br>
+                <a href="https://darkfoe.ca" class="text-secondary" target="_blank">My blog (closed source - NodeJS)</a></li>
+                <li class="list-group-item list-group-item-dark">Docker<br>
+                <a href="https://github.com/cfindlayisme/factorio-docker" target="_blank" class="text-secondary">factorio-docker</a><br>
+                <a href="https://github.com/cfindlayisme/terraria-docker" target="_blank" class="text-secondary">terraria-docker</a><br>
+            </ul>
+        `).fadeIn();
     });
 }
 


### PR DESCRIPTION
Replace backslash line continuations in main.js with template literals
for cleaner multiline HTML strings. Replace var with const for statcounter
config variables in index.html.

