### PR TITLE
Fix dark list-group-item background in portfolio section

### DIFF
--- a/html/css/main.css
+++ b/html/css/main.css
@@ -93,12 +93,12 @@ body {
   display: inline-block;
 }
 
-.list-group-item-dark {
+.list-group-item.list-group-item-dark {
   background-color: transparent;
   color: #fff;
   border-color: #444;
 }
 
-.list-group-item-dark + .list-group-item-dark {
+.list-group-item.list-group-item-dark + .list-group-item.list-group-item-dark {
   border-top-color: #444;
 }

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -94,7 +94,7 @@ body {
 }
 
 .list-group-item-dark {
-  background-color: #2a2a2a;
+  background-color: transparent;
   color: #fff;
   border-color: #444;
 }

--- a/html/css/main.css
+++ b/html/css/main.css
@@ -92,3 +92,13 @@ body {
 .list-group {
   display: inline-block;
 }
+
+.list-group-item-dark {
+  background-color: #2a2a2a;
+  color: #fff;
+  border-color: #444;
+}
+
+.list-group-item-dark + .list-group-item-dark {
+  border-top-color: #444;
+}


### PR DESCRIPTION
Bootstrap 4's list-group-item-dark class uses a light gray background (#c6c8ca)
which clashes with the site's dark theme. Override with a proper dark background
matching the rest of the page.